### PR TITLE
Do not enable and start chrony when running under lxd, lxc or openvz

### DIFF
--- a/data/virtual/lxc.yaml
+++ b/data/virtual/lxc.yaml
@@ -1,0 +1,4 @@
+---
+chrony::service_ensure: 'stopped'
+chrony::service_enable: false
+#  Clock synchronisation is not supported on lxd/lxc/openvz containers

--- a/data/virtual/openvz.yaml
+++ b/data/virtual/openvz.yaml
@@ -1,0 +1,1 @@
+lxc.yaml

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -12,5 +12,8 @@ hierarchy:
   - name: 'osfamily'
     path: "osfamily/%{facts.os.family}.yaml"
 
+  - name: "Virtualization platform"
+    path: "virtual/%{facts.virtual}.yaml"
+
   - name: 'common'
     path: 'common.yaml'


### PR DESCRIPTION
Clock synchronisation is not possible when running inside system containers, this avoids using external wrapper classes excluding some configurations.